### PR TITLE
Kaitai web IDE doesn't allow for capital letters

### DIFF
--- a/Kaitais/NANDBOOTINFO.ksy
+++ b/Kaitais/NANDBOOTINFO.ksy
@@ -1,5 +1,5 @@
 meta:
-  id: NANDBOOTINFO
+  id: nandbootinfo
   endian: be
 seq:
   - id: checksum


### PR DESCRIPTION
Fixes NANDBOOTINFO kaitai