### PR TITLE
Replace "clientID" with "mac_address"

### DIFF
--- a/Kaitais/mii.ksy
+++ b/Kaitais/mii.ksy
@@ -8,7 +8,7 @@ meta:
 seq:
   - id: invalid
     type: b1
-  - id: gender
+  - id: is_girl
     type: b1
   - id: birth_month
     type: b4
@@ -30,10 +30,8 @@ seq:
     type: u1
     repeat: expr
     repeat-expr: 4
-  - id: client_id
-    type: u1
-    repeat: expr
-    repeat-expr: 4
+  - id: mac_address
+    type: mac_address
   - id: face_type
     type: b3
   - id: face_color
@@ -140,3 +138,14 @@ seq:
     type: str
     size: 20
     encoding: utf-16be
+    
+types:
+  mac_address:
+    seq:
+      - id: checksum
+        type: u1
+        doc: The checksum is found by getting the sum of the first 3 bytes of the mac address, then modulo by 256.
+      - id: remaining_bytes
+        type: u1
+        repeat: expr
+        repeat-expr: 3

--- a/Kaitais/mii.ksy
+++ b/Kaitais/mii.ksy
@@ -26,10 +26,8 @@ seq:
     type: u1
   - id: body_weight
     type: u1
-  - id: avatar_id
-    type: u1
-    repeat: expr
-    repeat-expr: 4
+  - id: mii_id
+    type: mii_id
   - id: mac_address
     type: mac_address
   - id: face_type
@@ -149,3 +147,13 @@ types:
         type: u1
         repeat: expr
         repeat-expr: 3
+  mii_id:
+    seq:
+      - id: mii_info
+        type: u1
+        doc: According to HEYimHeroic, the first char is just information about the Mii. The second is apart of the timestamp.
+      - id: timestamp
+        type: u1
+        repeat: expr
+        repeat-expr: 3
+        doc: According to HEYimHeroic, these bytes are a timestamp of sorts, that can return the date it was created.


### PR DESCRIPTION
The first byte in `clientID` is actually a checksum8, found by adding the first 3 bytes of the Mac address then modulo the sum by 256. The remaining 3 bytes are just the remaining bytes in the Mac address.