### PR TITLE
Added another unknown value

### DIFF
--- a/Kaitais/ninch_dllist.ksy
+++ b/Kaitais/ninch_dllist.ksy
@@ -103,6 +103,8 @@ seq:
     size: 256
     encoding: utf-8
     doc: Part of the path in the URL for the Nintendo Channel files.
+  - id: unknown_10
+    type: u4
 instances:
   ratings_table:
     pos: ratings_table_offset


### PR DESCRIPTION
This value is in between the dl_url_id's and the ratings table. I didn't realize this until much later in creating a dllist, as I was confused when the company offsets were not lining up with what is in the title_table.

This PR is just to avoid confusion in the future